### PR TITLE
Display incoming remote commits in history list

### DIFF
--- a/Frontend/src/scripts/features/repo/history.ts
+++ b/Frontend/src/scripts/features/repo/history.ts
@@ -34,15 +34,31 @@ export function renderHistoryList(query: string): boolean {
     }
 
     const aheadIds: Set<string> = (state as any).aheadIds || new Set<string>();
+    let aheadFallbackRemaining = aheadIds.size > 0 ? 0 : ahead;
     commits.forEach((c, i) => {
         const li = document.createElement('li');
-        li.className = 'row commit';
+        const isIncoming = Boolean((c as any)?.incoming);
+        li.className = isIncoming ? 'row commit incoming' : 'row commit';
         const short = (c.id || '').slice(0, 7);
         const whenRaw = String(c.meta || '').split('•')[0].trim();
         const rel = formatTimeAgo(whenRaw);
         const exact = (c.meta || '').trim();
-        const isAhead = !!(c?.id && (aheadIds.size > 0 ? aheadIds.has(c.id) : (i < ahead)));
-        const statusTag = isAhead ? `<span class=\"tag up\" title=\"Not on remote yet\">↑ outgoing</span>` : '';
+        let isAhead = false;
+        if (c?.id) {
+            if (aheadIds.size > 0) {
+                isAhead = aheadIds.has(c.id);
+            } else if (!isIncoming && aheadFallbackRemaining > 0) {
+                isAhead = true;
+                aheadFallbackRemaining -= 1;
+            }
+        }
+        const remoteRef = String(((c as any)?.remoteRef || 'remote')).trim();
+        const remoteLabel = remoteRef === '@{upstream}' ? 'upstream' : remoteRef;
+        const statusTag = isAhead
+            ? `<span class=\"tag up\" title=\"Not on remote yet\">↑ outgoing</span>`
+            : isIncoming
+                ? `<span class=\"tag down\" title=\"${escapeHtml(`Fetched from ${remoteLabel}; pull to apply locally`)}\">↓ incoming</span>`
+                : '';
         li.innerHTML = `
         <span class="badge hash" title="${escapeHtml(c.id || '')}">${escapeHtml(short)}</span>
         <div class="file" title="${escapeHtml(c.msg || '')}">${escapeHtml(c.msg || '(no message)')}</div>

--- a/Frontend/src/scripts/features/repo/hydrate.ts
+++ b/Frontend/src/scripts/features/repo/hydrate.ts
@@ -49,7 +49,40 @@ export async function hydrateCommits() {
     try {
         const list = await TAURI.invoke<any[]>('git_log', { limit: 100 });
         state.hasRepo = true;
-        state.commits = Array.isArray(list) ? (list as any) : [];
+        const baseCommits = Array.isArray(list) ? (list as any) : [];
+        const behindCount = Number((state as any).behind || 0);
+        let incoming: any[] = [];
+        if (behindCount > 0) {
+            const limit = Math.min(Math.max(behindCount, 50), 500);
+            const branch = (state.branch || '').trim();
+            const ranges: { range: string; ref: string }[] = [
+                { range: 'HEAD..@{upstream}', ref: '@{upstream}' },
+            ];
+            if (branch) {
+                ranges.push({ range: `HEAD..origin/${branch}`, ref: `origin/${branch}` });
+            }
+            for (const { range, ref } of ranges) {
+                try {
+                    const remoteList = await TAURI.invoke<any[]>('git_log', { limit, rev: range });
+                    if (Array.isArray(remoteList) && remoteList.length > 0) {
+                        incoming = remoteList.map((c: any) => ({ ...c, incoming: true, remoteRef: ref }));
+                        break;
+                    }
+                } catch (err) {
+                    console.warn('hydrateCommits remote range failed', range, err);
+                }
+            }
+        }
+        const seen = new Set<string>();
+        const merged: any[] = [];
+        [...incoming, ...baseCommits].forEach((entry) => {
+            if (!entry || typeof entry !== 'object') return;
+            const id = String(entry.id || '');
+            if (!id || seen.has(id)) return;
+            seen.add(id);
+            merged.push(entry);
+        });
+        state.commits = merged;
         const aheadCount = Number((state as any).ahead || 0);
         if (aheadCount > 0) {
             try {

--- a/Frontend/src/scripts/types.d.ts
+++ b/Frontend/src/scripts/types.d.ts
@@ -21,6 +21,8 @@ export interface CommitItem {
     msg?: string;
     meta?: string;
     author?: string;
+    incoming?: boolean;
+    remoteRef?: string;
 }
 
 export interface StashItem {

--- a/Frontend/src/styles/components.css
+++ b/Frontend/src/styles/components.css
@@ -129,6 +129,7 @@ button:disabled,.btn:disabled,.btn.primary:disabled,.tbtn:disabled,.pick:disable
 /* Small status tag used in history list (outgoing marker) */
 .tag{ font-size:.72rem; color:var(--muted); border:1px solid var(--border); padding:.05rem .4rem; border-radius:999px; }
 .tag.up{ color:var(--success); border-color: rgba(38,162,105,.55); }
+.tag.down{ color:var(--accent); border-color:rgba(53,132,228,.55); border-color: color-mix(in oklab, var(--accent) 55%, transparent); }
 
 /* ========== Right pane (header | scroll | commit) ========== */
 .right{

--- a/crates/openvcs-git-libgit2/src/lowlevel.rs
+++ b/crates/openvcs-git-libgit2/src/lowlevel.rs
@@ -717,7 +717,14 @@ impl Git {
             let _ = walk.set_sorting(sort);
 
             let rev = q.rev.as_deref().unwrap_or("HEAD");
-            walk.push_ref(rev)?;
+            if rev.contains("..") {
+                walk.push_range(rev)?;
+            } else {
+                match repo.revparse_single(rev) {
+                    Ok(obj) => walk.push(obj.id())?,
+                    Err(_) => walk.push_ref(rev)?,
+                }
+            }
 
             // Pre-parse filters once
             let path_filter = q.path.as_deref();


### PR DESCRIPTION
## Summary
- surface commits fetched from upstream before they are pulled so the history list shows incoming work
- tag incoming entries in the UI and distinguish them from outgoing commits while keeping counts accurate
- allow the libgit2 backend to walk revision ranges so the remote history can be queried

## Testing
- cargo check -p openvcs-git-libgit2


------
https://chatgpt.com/codex/tasks/task_e_68d1b789662883229abc593a22b3d687