### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/Frontend/src/scripts/features/branches.ts
+++ b/Frontend/src/scripts/features/branches.ts
@@ -12,7 +12,7 @@ import { openRenameBranch } from './renameBranch';
 import { openSetUpstream } from './setUpstream';
 import { confirmDeleteBranch } from './deleteBranchConfirm';
 import { buildCtxMenu, CtxItem } from '../lib/menu';
-import { renderList, hydrateCommits, hydrateStatus } from './repo';
+import { renderList, hydrateStatus } from './repo';
 import { setTab } from '../ui/layout';
 import type { ConflictDetails, FileStatus } from '../types';
 import { openConflictsSummary } from './conflicts';


### PR DESCRIPTION
To fix the unused import, remove `hydrateCommits` from the named imports in this file, leaving only the actually used imports. This preserves existing behavior because named imports that are never referenced do not affect runtime semantics (they do not trigger additional side effects beyond importing the module, which is still imported because `renderList` and possibly `hydrateStatus` remain). Concretely, in `Frontend/src/scripts/features/branches.ts` at the import statement on line 15, delete `hydrateCommits` from the destructuring list so it becomes `import { renderList, hydrateStatus } from './repo';` (or, if `hydrateStatus` is also unused elsewhere in the full file and flagged by tools, you could similarly remove it, but per the report we will only adjust `hydrateCommits`). No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._