### PR TITLE
Follow-up: normalize Tauri before-command script paths

### DIFF
--- a/Backend/tauri.conf.json
+++ b/Backend/tauri.conf.json
@@ -3,7 +3,7 @@
   "productName": "OpenVCS",
   "identifier": "dev.jordon.openvcs",
   "build": {
-    "beforeDevCommand": "node ../Backend/scripts/run-tauri-before-command.js dev",
+    "beforeDevCommand": "node scripts/run-tauri-before-command.js dev",
     "beforeBuildCommand": "node scripts/run-tauri-before-command.js build",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../Frontend/dist"


### PR DESCRIPTION
### Motivation
- Fix an inconsistent relative path in `Backend/tauri.conf.json` so Tauri's `beforeDevCommand` and `beforeBuildCommand` both resolve from the `Backend/` directory in local development and CI workflows.

### Description
- Updated `Backend/tauri.conf.json` by changing `beforeDevCommand` from `node ../Backend/scripts/run-tauri-before-command.js dev` to `node scripts/run-tauri-before-command.js dev` so it matches the existing `beforeBuildCommand` path.

### Testing
- Validated the modified JSON with `python -m json.tool Backend/tauri.conf.json`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb702ff6e08322a509ef20a9277a97)