### PR TITLE
Make Tauri pre-build/dev hooks resilient to script location

### DIFF
--- a/Backend/tauri.conf.json
+++ b/Backend/tauri.conf.json
@@ -3,8 +3,8 @@
   "productName": "OpenVCS",
   "identifier": "dev.jordon.openvcs",
   "build": {
-    "beforeDevCommand": "node ../Backend/scripts/run-tauri-before-command.js dev",
-    "beforeBuildCommand": "node scripts/run-tauri-before-command.js build",
+    "beforeDevCommand": "node -e \"const {spawnSync}=require('node:child_process');const fs=require('node:fs');const path=require('node:path');const candidates=['scripts/run-tauri-before-command.js','Backend/scripts/run-tauri-before-command.js','../Backend/scripts/run-tauri-before-command.js','../../scripts/run-tauri-before-command.js'];const script=candidates.map((entry)=>path.resolve(process.cwd(),entry)).find((entry)=>fs.existsSync(entry));if(!script){console.error('Unable to locate Backend/scripts/run-tauri-before-command.js from cwd='+process.cwd());process.exit(1);}const result=spawnSync(process.execPath,[script,'dev'],{stdio:'inherit'});process.exit(result.status ?? 1);\"",
+    "beforeBuildCommand": "node -e \"const {spawnSync}=require('node:child_process');const fs=require('node:fs');const path=require('node:path');const candidates=['scripts/run-tauri-before-command.js','Backend/scripts/run-tauri-before-command.js','../Backend/scripts/run-tauri-before-command.js','../../scripts/run-tauri-before-command.js'];const script=candidates.map((entry)=>path.resolve(process.cwd(),entry)).find((entry)=>fs.existsSync(entry));if(!script){console.error('Unable to locate Backend/scripts/run-tauri-before-command.js from cwd='+process.cwd());process.exit(1);}const result=spawnSync(process.execPath,[script,'build'],{stdio:'inherit'});process.exit(result.status ?? 1);\"",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../Frontend/dist"
   },


### PR DESCRIPTION
### Motivation
- Ensure `Backend/scripts/run-tauri-before-command.js` is found and executed when running Tauri commands regardless of current working directory and provide a clear error if it cannot be located.

### Description
- Replaced `build.beforeDevCommand` and `build.beforeBuildCommand` in `Backend/tauri.conf.json` with inline `node -e` snippets that search multiple candidate paths, resolve them with `path.resolve`, and check existence with `fs.existsSync` before running the script via `spawnSync`.
- The inline script prints an error and exits non-zero when the target script is missing and forwards the executed script's exit code when present.

### Testing
- Ran `tauri dev` which invoked the new `beforeDevCommand` and completed successfully.
- Ran `tauri build` which invoked the new `beforeBuildCommand` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb702ff6e08322a509ef20a9277a97)