### PR TITLE
ci: fix opencode workflow auth setup for branch pushes

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
       - name: primary
         id: opencode_primary
@@ -40,6 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ vars.OPENCODE_DEFAULT_MODEL }}
+          use_github_token: true
 
       - name: fallback
         if: steps.opencode_primary.outcome == 'failure'
@@ -51,3 +52,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ vars.OPENCODE_DEFAULT_MODEL_FALLBACK }}
+          use_github_token: true


### PR DESCRIPTION
### Motivation
- The opencode workflow was failing to push fix branches with `remote: Duplicate header: "Authorization"` because the runner kept a persisted git credential while the opencode action also supplied a token.

### Description
- Set `persist-credentials: false` on the `actions/checkout@v6` step and enabled `use_github_token: true` for both the primary and fallback `anomalyco/opencode/github` steps in `.github/workflows/opencode.yml` so the action consistently manages GitHub auth.

### Testing
- Ran `git diff --check` which reported no issues and committed the change as `ci: fix opencode git auth configuration`, and the modification is a CI workflow-only fix (no application code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8bb528288322a68c276644a51c24)