### PR TITLE
Remove `GITHUB_TOKEN` env from opencode workflow steps

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -37,7 +37,6 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.ZEN_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ vars.OPENCODE_DEFAULT_MODEL }}
 
@@ -48,6 +47,5 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.ZEN_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ vars.OPENCODE_DEFAULT_MODEL_FALLBACK }}


### PR DESCRIPTION
### Motivation
- Remove explicit `GITHUB_TOKEN` environment variable from the `primary` and `fallback` steps to avoid passing the token unnecessarily through the action environment and rely on configured job permissions instead.

### Description
- Deleted `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` from the `primary` step in `.github/workflows/opencode.yml`.
- Deleted `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` from the `fallback` step in `.github/workflows/opencode.yml` and ensured the file ends with a newline.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8bb528288322a68c276644a51c24)