### PR TITLE
Disable use of GITHUB_TOKEN in opencode GitHub Action

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -37,9 +37,9 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.ZEN_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ vars.OPENCODE_DEFAULT_MODEL }}
+          use_github_token: false
 
       - name: fallback
         if: steps.opencode_primary.outcome == 'failure'
@@ -48,6 +48,6 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.ZEN_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: ${{ vars.OPENCODE_DEFAULT_MODEL_FALLBACK }}
+          use_github_token: false


### PR DESCRIPTION
### Motivation

- Prevent the opencode action from using the repository `GITHUB_TOKEN` and enforce use of external API keys for security.

### Description

- Remove the `GITHUB_TOKEN` environment variable and set `use_github_token: false` for both the `primary` and `fallback` opencode steps in `.github/workflows/opencode.yml`.

### Testing

- No automated tests were run for this PR; validation will occur when the updated GitHub Actions workflow executes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb8bb528288322a68c276644a51c24)