### PR TITLE
ci: fix invalid run-name expression in beta workflow

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,5 +1,5 @@
 name: Beta
-run-name: "OpenVCS Beta • Run #${{ github.run_number }} • Beta@${{ steps.meta.outputs.short_sha }}"
+run-name: "OpenVCS Beta • Run #${{ github.run_number }} • Beta@${{ github.sha }}"
 
 on:
   push:


### PR DESCRIPTION
### Motivation
- Fix GitHub Actions validation error caused by using the unavailable `steps` context in the top-level `run-name` of `.github/workflows/beta.yml`.

### Description
- Replaced the top-level `run-name` reference to `steps.meta.outputs.short_sha` in `.github/workflows/beta.yml` with the workflow-allowed `github.sha`, preserving the run-name format while removing the invalid context.

### Testing
- Verified the change with `git diff -- .github/workflows/beta.yml`, `git status --short`, and inspected the file with `nl -ba .github/workflows/beta.yml`, and confirmed the `run-name` no longer references `steps` (checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20ee4875c8322a2d457c58ffdb532)